### PR TITLE
auth metadata processor をフリーする

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,6 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
+   Copyright 2024 HERP, Inc.
    Copyright 2016 Awake Networks
    Copyright 2015 Alois Cochard https://github.com/aloiscochard/grpc-haskell
 

--- a/core/cbits/grpc_haskell.c
+++ b/core/cbits/grpc_haskell.c
@@ -488,12 +488,15 @@ grpc_auth_metadata_processor* mk_auth_metadata_processor(
                   const grpc_metadata *md, size_t num_md,
                   grpc_process_auth_metadata_done_cb cb, void *user_data)){
 
-  //TODO: figure out when to free this.
   grpc_auth_metadata_processor* p = malloc(sizeof(grpc_auth_metadata_processor));
   p->process = process;
   p->destroy = NULL;
   p->state = NULL;
   return p;
+}
+
+void grpc_destroy_auth_metadata_processor(grpc_auth_metadata_processor* p) {
+  free(p);
 }
 
 grpc_call_credentials* grpc_metadata_credentials_create_from_plugin_(

--- a/core/include/grpc_haskell.h
+++ b/core/include/grpc_haskell.h
@@ -189,6 +189,8 @@ grpc_auth_metadata_processor* mk_auth_metadata_processor(
                   const grpc_metadata *md, size_t num_md,
                   grpc_process_auth_metadata_done_cb cb, void *user_data));
 
+void grpc_destroy_auth_metadata_processor(grpc_auth_metadata_processor* p);
+
 grpc_call_credentials* grpc_metadata_credentials_create_from_plugin_(
   grpc_metadata_credentials_plugin* plugin);
 

--- a/core/src/Network/GRPC/Unsafe/Security.chs
+++ b/core/src/Network/GRPC/Unsafe/Security.chs
@@ -292,6 +292,12 @@ foreign import ccall "dynamic"
 foreign import ccall "grpc_haskell.h mk_auth_metadata_processor"
   mkAuthMetadataProcessor :: FunPtr CAuthProcess -> IO AuthMetadataProcessor
 
+{#fun destroy_auth_metadata_processor as ^ {`AuthMetadataProcessor'} -> `()'#}
+
+withAuthMetadataProcessor :: FunPtr CAuthProcess -> (AuthMetadataProcessor -> IO a) -> IO a
+withAuthMetadataProcessor process =
+  bracket (mkAuthMetadataProcessor process) destroyAuthMetadataProcessor
+
 data AuthProcessorResult = AuthProcessorResult
   { resultConsumedMetadata :: MetadataMap
   -- ^ Metadata to remove from the request before passing to the handler.
@@ -337,8 +343,8 @@ setMetadataProcessor :: ServerCredentials -> ProcessMeta -> IO ()
 setMetadataProcessor creds processor = do
   let rawProcessor = convertProcessor processor
   rawProcessorPtr <- mkAuthProcess rawProcessor
-  metaProcessor <- mkAuthMetadataProcessor rawProcessorPtr
-  serverCredentialsSetAuthMetadataProcessor creds metaProcessor
+  withAuthMetadataProcessor rawProcessorPtr $ \metaProcessor ->
+    serverCredentialsSetAuthMetadataProcessor creds metaProcessor
 
 -- * Client-side metadata plugins
 


### PR DESCRIPTION
`mk_auth_metadata_processor` で `malloc` され確保された `grpc_auth_metadata_processor` が `free` されていないため `free` するようにする。

# 確保された `grpc_auth_metadata_processor` を追う

`mk_auth_metadata_processor` で確保され返り値で返されている（_core/cbits/grpc_haskell.c_）。

```c
grpc_auth_metadata_processor* mk_auth_metadata_processor(…){
  grpc_auth_metadata_processor* p = malloc(sizeof(grpc_auth_metadata_processor));
  …
  return p;
}
```

これは C→Haskell でラップされ `setMetadataProcessor` から呼ばれている。確保された領域へのポインターは `serverCredentialsSetAuthMetadataProcessor` に渡される（_core/src/Network/GRPC/Unsafe/Security.chs_）。

```chs
-- | Sets the custom metadata processor for the given server credentials.
setMetadataProcessor :: ServerCredentials -> ProcessMeta -> IO ()
setMetadataProcessor creds processor = do
  …
  metaProcessor <- mkAuthMetadataProcessor rawProcessorPtr
  serverCredentialsSetAuthMetadataProcessor creds metaProcessor
```

`serverCredentialsSetAuthMetadataProcessor` も C→Haskell でラップされた関数であり元は C の `grpc_server_credentials_set_auth_metadata_processor_` である（_core/src/Network/GRPC/Unsafe/Security.chs_・_core/cbits/grpc_haskell.c_）。

```chs
{#context prefix = "grpc_"#}
…
{#fun server_credentials_set_auth_metadata_processor_ as ^
  {`ServerCredentials', `AuthMetadataProcessor'} -> `()'#}
```

```c
void grpc_server_credentials_set_auth_metadata_processor_(
  grpc_server_credentials* creds, grpc_auth_metadata_processor* p){

  grpc_server_credentials_set_auth_metadata_processor(creds, *p);
}
```

ここで第2引数 `grpc_auth_metadata_processor* p` は `grpc_server_credentials_set_auth_metadata_processor` に渡されているが、値渡しされている、つまり `p` の指す領域はコールスタックにコピーされるためこの後 `p` を `free` して問題ないはず。

# 改修方法

以上から `serverCredentialsSetAuthMetadataProcessor` の実行後は `mk_auth_metadata_processor` で確保した領域は `free` することにする。

`free` する関数 `destroyAuthMetadataProcessor` を用意し、`bracket` パターンで `withAuthMetadataProcessor` を利用するように改修する。