### PR TITLE
ghc9.8対応

### DIFF
--- a/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
-
+#if MIN_VERSION_GLASGOW_HASKELL(9,8,0,0)
+{-# OPTIONS -Wno-x-partial #-}
+#endif
 module Network.GRPC.LowLevel.GRPC.MetadataMap where
 
 import Data.ByteString (ByteString)


### PR DESCRIPTION
`MetaDataMap` モジュールの `head` を使っている部分でエラーが出ないように `-Wno-x-partial` を追加
この `head` は `groupBy` した各要素に対して使っているので安全である
またghc9.6とghc9.8でビルドできることを確認した