### PR TITLE
Fix metadata slice leak when freeing metadata

### DIFF
--- a/core/cbits/grpc_haskell.c
+++ b/core/cbits/grpc_haskell.c
@@ -183,6 +183,15 @@ void metadata_free(grpc_metadata* m){
   grpc_haskell_free("metadata_free", m);
 }
 
+void metadata_free_full(grpc_metadata* m, size_t n){
+  size_t i;
+  for(i = 0; i < n; i++){
+    grpc_slice_unref((m + i)->key);
+    grpc_slice_unref((m + i)->value);
+  }
+  grpc_haskell_free("metadata_free_full", m);
+}
+
 void set_metadata_key_val(char *key, char *val, size_t val_len,
                           grpc_metadata *arr, size_t i){
   grpc_metadata *p = arr + i;

--- a/core/include/grpc_haskell.h
+++ b/core/include/grpc_haskell.h
@@ -68,6 +68,7 @@ void metadata_array_destroy(grpc_metadata_array **arr);
 grpc_metadata* metadata_alloc(size_t n);
 
 void metadata_free(grpc_metadata* m);
+void metadata_free_full(grpc_metadata* m, size_t n);
 
 void set_metadata_key_val(char *key, char *val, size_t val_len,
                           grpc_metadata *arr, size_t i);

--- a/core/src/Network/GRPC/LowLevel/Op.hs
+++ b/core/src/Network/GRPC/LowLevel/Op.hs
@@ -104,12 +104,12 @@ setOpArray arr i (OpRecvCloseOnServerContext pcancelled) = do
 
 -- | Cleans up an 'OpContext'.
 freeOpContext :: OpContext -> IO ()
-freeOpContext (OpSendInitialMetadataContext m _) = C.metadataFree m
+freeOpContext (OpSendInitialMetadataContext m l) = C.metadataFreeFull m l
 freeOpContext (OpSendMessageContext (bb, s)) =
   C.grpcByteBufferDestroy bb >> C.freeSlice s
 freeOpContext OpSendCloseFromClientContext = return ()
-freeOpContext (OpSendStatusFromServerContext metadata _ _ s) =
-  C.metadataFree metadata >> C.freeSlice s
+freeOpContext (OpSendStatusFromServerContext metadata l _ s) =
+  C.metadataFreeFull metadata l >> C.freeSlice s
 freeOpContext (OpRecvInitialMetadataContext metadata) =
   C.metadataArrayDestroy metadata
 freeOpContext (OpRecvMessageContext pbb) =

--- a/core/src/Network/GRPC/Unsafe/Metadata.chs
+++ b/core/src/Network/GRPC/Unsafe/Metadata.chs
@@ -62,6 +62,7 @@ instance Storable MetadataArray where
 {#fun unsafe metadata_alloc as ^ {`Int'} -> `MetadataKeyValPtr'#}
 
 {#fun unsafe metadata_free as ^ {`MetadataKeyValPtr'} -> `()'#}
+{#fun unsafe metadata_free_full as ^ {`MetadataKeyValPtr', `Int'} -> `()'#}
 
 -- | Sets a metadata key/value pair at the given index in the
 -- 'MetadataKeyValPtr'. No error checking is performed to ensure the index is
@@ -88,7 +89,7 @@ withMetadataArrayPtr :: (Ptr MetadataArray -> IO a) -> IO a
 withMetadataArrayPtr = bracket metadataArrayCreate metadataArrayDestroy
 
 withMetadataKeyValPtr :: Int -> (MetadataKeyValPtr -> IO a) -> IO a
-withMetadataKeyValPtr i f = bracket (metadataAlloc i) metadataFree f
+withMetadataKeyValPtr i f = bracket (metadataAlloc i) (`metadataFreeFull` i) f
 
 getMetadataKey :: MetadataKeyValPtr -> Int -> IO ByteString
 getMetadataKey m = getMetadataKey' m >=> sliceToByteString
@@ -109,7 +110,7 @@ withPopulatedMetadataKeyValPtr :: MetadataMap
                                   -> ((MetadataKeyValPtr, Int) -> IO a)
                                   -> IO a
 withPopulatedMetadataKeyValPtr m = bracket (createMetadata m)
-                                           (metadataFree . fst)
+                                           (uncurry metadataFreeFull)
 
 getAllMetadataArray :: MetadataArray -> IO MetadataMap
 getAllMetadataArray m = do


### PR DESCRIPTION
MetadataMapのfree時に個々の要素もfreeする。
これによってメモリリークが直ったことは確認した。